### PR TITLE
feat: :sparkles: added time_series_weekly method

### DIFF
--- a/libs/langchain/langchain/utilities/alpha_vantage.py
+++ b/libs/langchain/langchain/utilities/alpha_vantage.py
@@ -31,6 +31,26 @@ class AlphaVantageAPIWrapper(BaseModel):
         )
         return values
 
+    def _get_time_series_weekly(
+        self, symbol: str
+    ) -> Dict[str, Any]:
+        """Make a request to the AlphaVantage API to get the Weekly Time Series."""
+        response = requests.get(
+            "https://www.alphavantage.co/query/",
+            params={
+                "function": "TIME_SERIES_WEEKLY",
+                "symbol": symbol,
+                "apikey": self.alphavantage_api_key,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if "Error Message" in data:
+            raise ValueError(f"API Error: {data['Error Message']}")
+
+        return data
+
     def _get_exchange_rate(
         self, from_currency: str, to_currency: str
     ) -> Dict[str, Any]:


### PR DESCRIPTION
### Description
Added a new method `_get_time_series_weekly` to the `AlphaVantageAPIWrapper` class. This method leverages the `TIME_SERIES_WEEKLY` function from the Alpha Vantage API to retrieve weekly time series data for a specified stock symbol. It provides key weekly stock data, such as open, high, low, close prices, and volume, which is essential for financial analysis, particularly for longer-term investment strategies.

### Issue
- Issue #11994

### Dependencies
- Requires the requests library for making API calls.
- An Alpha Vantage API key is necessary, either set as an environment variable or passed as an argument.

### Usage
Here’s how to use the `_get_time_series_weekly` method:
```python
wrapper = AlphaVantageAPIWrapper(alphavantage_api_key="your_api_key")
weekly_data = wrapper._get_time_series_weekly("GOOGL")
print(weekly_data)
